### PR TITLE
Update Makefile to get things compiling

### DIFF
--- a/jni/chicken/Makefile
+++ b/jni/chicken/Makefile
@@ -46,17 +46,16 @@ android-toolchain: $(ANDROID_TOOLCHAIN)/
 
 $(ANDROID_TOOLCHAIN)/:
 	mkdir -p $(ANDROID_TOOLCHAIN) && \
-	$(ANDROID_NDK)/build/tools/make-standalone-toolchain.sh \
+	$(ANDROID_NDK)/build/tools/make-standalone-toolchain.sh --force \
 	  --platform=$(ANDROID_PLATFORM) \
 	  --toolchain=arm-linux-androideabi-4.8 \
-	  --system=linux-x86_64 \
 	  --install-dir=$(ANDROID_TOOLCHAIN)
 
 chicken-sources: $(CHICKEN_CORE)/
 
 $(CHICKEN_CORE)/:
 	git clone --depth 1 git://code.call-cc.org/chicken-core \
-		-b 4.9.0.1 \
+		-b 4.11.0 \
 		$(CHICKEN_CORE)
 
 # build chicken-boot unless binary already present


### PR DESCRIPTION
My installation: Chicken 4.11 on a 64bit Ubuntu 16.04 VM:
It looks like a Chicken 4.11.0 cannot bootstrap 4.9.0.1. Also the make-standalone-toolchain script needs minor changes.
Besides that it is needed to execute:
```
android update project -p . -t android-21 (or android-18)
```
An unfortunately in the end there are still some linking errors with SDL:
```
[arm64-v8a] Install        : libSDL2.so => libs/arm64-v8a/libSDL2.so
[arm64-v8a] Install        : libchicken.so => libs/arm64-v8a/libchicken.so
[arm64-v8a] Compile        : main <= entry.c
[arm64-v8a] SharedLibrary  : libmain.so
./obj/local/arm64-v8a/libchicken.so: error adding symbols: File in wrong format
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
/home/lihovac/Android/Sdk/ndk-bundle/build/core/build-binary.mk:702: recipe for target 'obj/local/arm64-v8a/libmain.so' failed
make[1]: *** [obj/local/arm64-v8a/libmain.so] Error 1
make[1]: Leaving directory '/home/lihovac/src/others/chicken-android-template'
Makefile:15: recipe for target 'compile' failed
make: *** [compile] Error 2
```